### PR TITLE
Test buildpack with docker and fix moving binary to build folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:latest
+    steps:
+      - checkout
+      - run:
+          name: Install Container Structure Test
+          command: |
+            curl -fLO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64 && \
+            chmod +x container-structure-test-linux-amd64 && \
+            mkdir -p $HOME/bin && \
+            mv container-structure-test-linux-amd64 $HOME/bin/container-structure-test \
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: 18.09.3
+      - run:
+          name: Run tests
+          command: ./bin/container-test
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM heroku/heroku:18
+
+COPY . /tmp/buildpack
+
+RUN mkdir /tmp/build /tmp/cache /tmp/env
+
+RUN /tmp/buildpack/bin/detect /tmp/build
+RUN /tmp/buildpack/bin/compile /tmp/build /tmp/cache /tmp/env

--- a/bin/compile
+++ b/bin/compile
@@ -33,8 +33,8 @@ rm -rf /tmp/awscli
 
 "$BUILD_DIR/.awscli/awscli-bundle/install" -i "$INSTALL_DIR" |& indent
 
-if [ "$BUILD_DIR" != "/app" ]; then
-  mv $INSTALL_DIR "$BUILD_DIR/.awscli"
+if [ "$INSTALL_DIR" != "$BUILD_DIR/.awscli" ]; then
+  mv $INSTALL_DIR/* "$BUILD_DIR/.awscli"
 fi
 
 # Restore the moved awscli dir, if it exists.

--- a/bin/container-test
+++ b/bin/container-test
@@ -1,0 +1,10 @@
+#!/bin/sh -eu
+
+tagName="heroku-buildpack-awscli"
+
+echo "Testing Buildpack with Docker"
+docker build -t $tagName -f Dockerfile .
+
+$HOME/bin/container-structure-test test \
+  --image $tagName \
+  --config container-structure-test.yaml

--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -1,0 +1,10 @@
+schemaVersion: 2.0.0
+fileExistenceTests:
+  - name: 'awscli'
+    path: '/tmp/build/.awscli/bin/aws'
+    shouldExist: true
+    permissions: '-rwxr-xr-x'
+  - name: 'profile-d'
+    path: '/tmp/build/.profile.d/awscli.sh'
+    shouldExist: true
+    permissions: '-rw-r--r--'


### PR DESCRIPTION
This uses [container-structure-test](https://github.com/GoogleContainerTools/container-structure-test) to check the behavior of the buildpack.
It also fixes moving the files into the build folder. We were previously moving things into `$BUILD_DIR/.awscli/.awscli`.