### PR TITLE
Enable stricter bash error checking modes

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir> <env-dir>
 
-set -e
+set -euo pipefail
 
 function indent() {
   c='s/^/       /'


### PR DESCRIPTION
Enables the following bash modes:
- `u`: error on undefined variables
- `pipefail`: error if an earlier command in a pipe sequence exits non-zero, rather than only if the final command is non-zero

See:
http://redsymbol.net/articles/unofficial-bash-strict-mode/

Fixes #13.