### PR TITLE
Update to AWS CLI v2

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,43 +11,44 @@ function indent() {
   esac
 }
 
-# config
-AWS_CLI_URL="https://s3.amazonaws.com/aws-cli/awscli-bundle.zip"
+AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
 
-# parse and derive params
 BUILD_DIR=$1
-CACHE_DIR=$2
-
 BUILDPACK_DIR="$(dirname $(dirname $0))"
 INSTALL_DIR="/app/.awscli"
+TMP_DIR=$(mktemp -d)
+
+echo "-----> Downloading AWS CLI"
+curl --silent --show-error --fail -o "${TMP_DIR}/awscliv2.zip" "${AWS_CLI_URL}" |& indent
+unzip -qq -d "${TMP_DIR}" "${TMP_DIR}/awscliv2.zip" |& indent
 
 echo "-----> Installing AWS CLI"
-curl --silent --show-error -o /tmp/awscli-bundle.zip "$AWS_CLI_URL" |& indent
-unzip -qq -d "$BUILD_DIR/.awscli" /tmp/awscli-bundle.zip |& indent
+mkdir -p "${BUILD_DIR}/.awscli"
 
-# Since build-dir isn't guaranteed to be /app, move whatever's in /app's awscli
-# dir out of the way. The installer uses virtualenv, which means it must be
-# installed in the final location - we have to install into /app.
-rm -rf /tmp/awscli
-
-# Since $BUILD_DIR can be /app, we can only move $INSTALL_DIR if it's not the same.
-if [ "$INSTALL_DIR" != "$BUILD_DIR/.awscli" ] && [ -e $INSTALL_DIR ]; then
-  mv $INSTALL_DIR /tmp/awscli
+# The AWS installer creates symlinks that use absolute paths, as such the install
+# location must match the location from which the CLI is eventually run.
+# At runtime the app will be run from /app, however at build time $BUILD_DIR is
+# typically a path under /tmp (unless a Heroku CI build, in which case it's /app).
+# In order to make all cases work, we have to create a symlink from /app to $BUILD_DIR,
+# so that we can use `/app` paths for the installer, so that the symlinks it creates
+# will use /app paths. A symlink is used instead of file copying to improve build times.
+if [[ "${BUILD_DIR}" != /app ]]; then
+  mkdir -p /app
+  ln -nsf "${BUILD_DIR}/.awscli" "${INSTALL_DIR}"
 fi
 
-"$BUILD_DIR/.awscli/awscli-bundle/install" -i "$INSTALL_DIR" |& indent
+"${TMP_DIR}/aws/install" --install-dir "${INSTALL_DIR}/aws-cli" --bin-dir "${INSTALL_DIR}/bin" |& indent
+/app/.awscli/bin/aws --version |& indent
 
-if [ "$INSTALL_DIR" != "$BUILD_DIR/.awscli" ]; then
-  mv $INSTALL_DIR/* "$BUILD_DIR/.awscli"
-fi
-
-# Restore the moved awscli dir, if it exists.
-[ -e /tmp/awscli ] && mv /tmp/awscli $INSTALL_DIR
-
-mkdir -p $BUILD_DIR/.profile.d
-cat > "$BUILD_DIR/.profile.d/awscli.sh" <<'PROFILE'
-export PATH="$HOME/.awscli/bin:$PATH"
+mkdir -p "${BUILD_DIR}/.profile.d"
+cat > "${BUILD_DIR}/.profile.d/awscli.sh" <<'PROFILE'
+export PATH="/app/.awscli/bin:${PATH}"
 PROFILE
 
-#cleaning up...
-rm -rf /tmp/awscli*
+cat > "${BUILDPACK_DIR}/export" <<'EXPORT'
+export PATH="/app/.awscli/bin:${PATH}"
+EXPORT
+
+rm -rf "${TMP_DIR}"
+
+echo "-----> Successfully installed AWS CLI"

--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -3,8 +3,22 @@ fileExistenceTests:
   - name: 'awscli'
     path: '/tmp/build/.awscli/bin/aws'
     shouldExist: true
-    permissions: '-rwxr-xr-x'
+    permissions: 'Lrwxrwxrwx'
   - name: 'profile-d'
     path: '/tmp/build/.profile.d/awscli.sh'
     shouldExist: true
     permissions: '-rw-r--r--'
+  - name: 'export'
+    path: '/tmp/buildpack/export'
+    shouldExist: true
+    permissions: '-rw-r--r--'
+commandTests:
+  - name: 'awscli is runnable at build time'
+    command: 'bash'
+    args: ['-c', 'source /tmp/buildpack/export && aws --version']
+    expectedOutput: ['aws-cli/2\.*']
+  - name: 'awscli is runnable at run time'
+    setup: [['rm', '-rf', '/app'], ['mv', '/tmp/build', '/app']]
+    command: 'bash'
+    args: ['-c', 'source /app/.profile.d/awscli.sh && aws --version']
+    expectedOutput: ['aws-cli/2\.*']


### PR DESCRIPTION
Updates from the deprecated v1 AWS CLI to v2:
https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html
https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst

This fixes compatibility with Heroku-20.

In addition:
* the file copying approach to working around non-relocatability has been replaced with a symlink approach for faster build times.
* this approach also means using an `export` file is now viable, so one has been created allowing later buildpacks to use the CLI and not just runtime use-cases.
* the buildpack now outputs the installed version to the log, for easier debugging.

This is a breaking change, however:
1. The scope of the breaking changes is pretty small (https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html)
2. The v1 CLI is deprecated, so we're going to have to rip this band aid off at some point
3. There isn't a much better way to fix the Heroku-20 incompatibility other than updating, and having split versions per stack isn't ideal either
4. The build output now shows the CLI version, so users encountering errors can see that something changed with the CLI due to difference in build output, and can pin to an older buildpack version
5. Usage of this buildpack is very low (looking at build metrics) and given this buildpack is AWS related will skew towards more technical users who will be able to pin the buildpack if needs be.

Fixes #7.
Fixes #12.
Closes [W-8520499](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008kVmIIAU/view).