### PR TITLE
Allowing running tests more easily locally

### DIFF
--- a/bin/container-test
+++ b/bin/container-test
@@ -1,10 +1,19 @@
-#!/bin/sh -eu
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v container-structure-test &> /dev/null; then
+  echo "container-structure-test not found! Please install and ensure it's on PATH," >&2
+  echo "via either 'brew install container-structure-test' or downloading from:" >&2
+  echo "https://github.com/GoogleContainerTools/container-structure-test" >&2
+  exit 1
+fi
 
 tagName="heroku-buildpack-awscli"
 
 echo "Testing Buildpack with Docker"
 docker build -t $tagName -f Dockerfile .
 
-$HOME/bin/container-structure-test test \
+container-structure-test test \
   --image $tagName \
   --config container-structure-test.yaml


### PR DESCRIPTION
* `container-structure-test` now just needs to be anywhere on `PATH`, rather than specifically in `$HOME/bin/`, fixing running the tests locally when using the homebrew install of `container-structure-test`. This still works on Circle, since the `circleci/golang` image already has `$HOME/bin/` on `PATH`.
* if `container-structure-test` is not installed, the error message now says how to obtain it.
* `bin/container-test` now uses `bash` rather than `sh` and also sets the bash modes via explicit calls rather than the shebang.

Refs [W-8520499](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008kVmIIAU/view).